### PR TITLE
Updated google_auth.py for scope changes

### DIFF
--- a/inginious/frontend/plugins/auth/google_auth.py
+++ b/inginious/frontend/plugins/auth/google_auth.py
@@ -16,8 +16,8 @@ from inginious.frontend.user_manager import AuthMethod
 authorization_base_url = 'https://accounts.google.com/o/oauth2/v2/auth'
 token_url = 'https://www.googleapis.com/oauth2/v4/token'
 scope = [
-    "email",
-    "profile"
+    "https://www.googleapis.com/auth/userinfo.email",
+    "https://www.googleapis.com/auth/userinfo.profile"
 ]
 
 class GoogleAuthMethod(AuthMethod):


### PR DESCRIPTION
Google recently changed scope attributes. Using new scope attributes fixes this. 
Scope has changed from "email profile" to "https://www.googleapis.com/auth/userinfo.profile https://www.googleapis.com/auth/